### PR TITLE
ensure that run_in targets include direct tool deps

### DIFF
--- a/multitool/private/run_in.bzl
+++ b/multitool/private/run_in.bzl
@@ -36,4 +36,7 @@ def run_in(ctx, env_var):
             "{{env_var}}": env_var,
         },
     )
-    return [DefaultInfo(executable = output, runfiles = ctx.attr.tool[DefaultInfo].default_runfiles)]
+
+    runfiles = ctx.runfiles(ctx.files.tool)
+    runfiles = runfiles.merge(ctx.attr.tool[DefaultInfo].default_runfiles)
+    return [DefaultInfo(executable = output, runfiles = runfiles)]


### PR DESCRIPTION
This change makes sure that, if the tool is a http_file, that the file's //downloaded target ends up in the runfiles set.